### PR TITLE
fix typescript enum default value

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -330,8 +330,14 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
     public String toDefaultValue(Property p) {
         if (p instanceof StringProperty) {
             StringProperty sp = (StringProperty) p;
-            if (sp.getDefault() != null) {
-                return "'" + sp.getDefault() + "'";
+            String _default = sp.getDefault();
+            if (_default != null) {
+                if (sp.getEnum() == null) {
+                    return "'" + escapeText(_default) + "'";
+                } else {
+                    // convert to enum var name later in postProcessModels
+                    return _default;
+                }
             }
             return UNDEFINED_VALUE;
         } else if (p instanceof BooleanProperty) {
@@ -431,13 +437,8 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
         if ("number".equals(datatype)) {
             return value;
         } else {
-            return "\'" + escapeText(value) + "\'";
+            return "'" + escapeText(value) + "'";
         }
-    }
-
-    @Override
-    public String toEnumDefaultValue(String value, String datatype) {
-        return datatype + "_" + value;
     }
 
     @Override
@@ -500,6 +501,9 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
             for (CodegenProperty var : cm.allVars) {
                 if (Boolean.TRUE.equals(var.isEnum)) {
                     var.datatypeWithEnum = var.datatypeWithEnum.replace(var.enumName, cm.classname + "Enums." + var.enumName);
+                    if (var.defaultValue != null) {
+                        var.defaultValue = var.defaultValue.replace(var.enumName, cm.classname + "Enums." + var.enumName);
+                    }
                 }
             }
         }
@@ -528,6 +532,9 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
                        for (CodegenProperty var : child.allVars) {
                            if (var.isEnum && isEnumInModel(cm, var.enumName)) {
                                var.datatypeWithEnum = var.datatypeWithEnum.replace(child.classname, cm.classname);
+                               if (var.defaultValue != null) {
+                                   var.defaultValue = var.defaultValue.replace(child.classname, cm.classname);
+                               }
                                child.enumImports.add(cm.classname);
                            }
                        }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -463,21 +463,4 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         String name = filename.substring((modelPackage() + "/").length());
         return camelize(name);
     }
-
-    @Override
-    public void updateCodegenPropertyEnum(CodegenProperty var) {
-        super.updateCodegenPropertyEnum(var);
-
-        // Fix enum with default value
-        if (var.isEnum) {
-            var.defaultValue = toEnumDefaultValue(var.defaultValue, "string");
-        }
-    }
-
-    @Override
-    public String toEnumDefaultValue(String value, String datatype) {
-        return "'" + toEnumVarName(value, datatype) + "'";
-    }
-
-
 }


### PR DESCRIPTION
Fixing enum `defaultValue` for TypeScript.

The `defaultValue` is supposed to be something that you just set a variable of the enum type to, like:

```typescript
    private xablau: XablauEnum = {{{defaultValue}}};
```

This change makes it so, by copying over some code from the Java generator to `toDefaultValue()`! That way, the name stays unmodified by quotes all the way to `postProcessModelsEnum()` -> `updateCodegenPropertyEnum()` and is able to match against the `enumVars` map (see https://github.com/sigriston/swagger-codegen/blob/7dc3ee4f6768060efff40537997affa2c060ef28/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java#L3818-L3829), being replaced by the correct enum name/symbol.

The other patches (`postProcessModels()` and `postProcessAllModels()`) are necessary to support enums embedded into a parent class of the model.